### PR TITLE
Integrate central versioning schema from 25.0.0.2

### DIFF
--- a/cadwiki-nuget/CadDevToolsDriver/Properties/AssemblyInfo.cs
+++ b/cadwiki-nuget/CadDevToolsDriver/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("4.1.0.1")]
-[assembly: AssemblyFileVersion("4.1.0.1")]
+[assembly: AssemblyVersion("25.0.0.2")]
+[assembly: AssemblyFileVersion("25.0.0.2")]

--- a/cadwiki-nuget/Directory.Build.props
+++ b/cadwiki-nuget/Directory.Build.props
@@ -1,5 +1,24 @@
 <Project>
   <PropertyGroup>
     <NoWarn>168,1591,42016,41999,42017,42018,42019,42032,42036,42020,42021,42022,162,649,1717,219,67,414,4244,414,MSB3270,3270</NoWarn>
+    <!-- Required when restoring/building net8.0-windows projects on non-Windows (macOS/Linux) -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+
+    <!-- ═══════════════════════════════════════════════════════════════════
+         Central Versioning Schema — single source of truth for all projects.
+         Update these four properties for a new release; all AssemblyInfo.cs
+         files and SDK-style projects inherit from here.
+         ═══════════════════════════════════════════════════════════════════ -->
+    <CadwikiVersionMajor>25</CadwikiVersionMajor>
+    <CadwikiVersionMinor>0</CadwikiVersionMinor>
+    <CadwikiVersionBuild>0</CadwikiVersionBuild>
+    <CadwikiVersionRevision>2</CadwikiVersionRevision>
+    <CadwikiVersion>$(CadwikiVersionMajor).$(CadwikiVersionMinor).$(CadwikiVersionBuild).$(CadwikiVersionRevision)</CadwikiVersion>
+
+    <!-- Feed the SDK-style Version / AssemblyVersion / FileVersion properties -->
+    <Version>$(CadwikiVersion)</Version>
+    <AssemblyVersion>$(CadwikiVersion)</AssemblyVersion>
+    <FileVersion>$(CadwikiVersion)</FileVersion>
+    <InformationalVersion>$(CadwikiVersion)</InformationalVersion>
   </PropertyGroup>
 </Project>

--- a/cadwiki-nuget/cadwiki.AC25.Interop/Properties/AssemblyInfo.cs
+++ b/cadwiki-nuget/cadwiki.AC25.Interop/Properties/AssemblyInfo.cs
@@ -1,26 +1,21 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("AutoCADAddin")]
+[assembly: AssemblyTitle("cadwiki.AC25.Interop")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("AutoCADAddin")]
-[assembly: AssemblyCopyright("Copyright ©  2024")]
+[assembly: AssemblyCompany("cadwiki")]
+[assembly: AssemblyProduct("cadwiki.AC25.Interop")]
+[assembly: AssemblyCopyright("")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
+// to COM components.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("ca712c85-7d4c-4918-bd17-a247d1326a95")]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -29,8 +24,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("25.0.0.2")]
 [assembly: AssemblyFileVersion("25.0.0.2")]

--- a/cadwiki-nuget/cadwiki.AutoCAD2022.Interop.Utilities/Properties/AssemblyInfo.cs
+++ b/cadwiki-nuget/cadwiki.AutoCAD2022.Interop.Utilities/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("4.0.0.1")]
-[assembly: AssemblyFileVersion("4.0.0.1")]
+[assembly: AssemblyVersion("25.0.0.2")]
+[assembly: AssemblyFileVersion("25.0.0.2")]

--- a/cadwiki-nuget/cadwiki.CadDevTools/Properties/AssemblyInfo.cs
+++ b/cadwiki-nuget/cadwiki.CadDevTools/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("4.1.0.1")]
-[assembly: AssemblyFileVersion("4.1.0.1")]
+[assembly: AssemblyVersion("25.0.0.2")]
+[assembly: AssemblyFileVersion("25.0.0.2")]

--- a/cadwiki-nuget/cadwiki.DllReloader/cadwiki.DllReloader.csproj
+++ b/cadwiki-nuget/cadwiki.DllReloader/cadwiki.DllReloader.csproj
@@ -21,7 +21,7 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
   </PropertyGroup>
-  <Target Name="CopyAcRemoveCmdGroup" AfterTargets="Build">
+  <Target Name="CopyAcRemoveCmdGroup" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
     <Exec Command="echo The build root is: $(BuildRoot)" />
     <Exec Command="echo AcRemoveCmdGroup.dll location is: $(BuildRoot)\cadwiki.AcRemoveCmdGroup\x64\$(Configuration)\cadwiki.AcRemoveCmdGroup.dll" />
     <Exec Command="xcopy /S /Q /Y /F $(BuildRoot)\x64\$(Configuration)\cadwiki.AcRemoveCmdGroup.dll $(TargetDir)\" />
@@ -104,7 +104,7 @@
     <Import Include="System.Threading.Tasks" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\cadwiki.AcRemoveCmdGroup\cadwiki.AcRemoveCmdGroup.vcxproj" />
+    <ProjectReference Condition="'$(OS)' == 'Windows_NT'" Include="..\cadwiki.AcRemoveCmdGroup\cadwiki.AcRemoveCmdGroup.vcxproj" />
     <ProjectReference Include="..\cadwiki.NetUtils\cadwiki.NetUtils.csproj" />
     <ProjectReference Include="..\cadwiki.NUnitTestRunner\cadwiki.NUnitTestRunner.csproj" />
     <ProjectReference Include="..\cadwiki.WpfUi\cadwiki.WpfUi.csproj" />

--- a/cadwiki-nuget/cadwiki.MVVM/Properties/AssemblyInfo.cs
+++ b/cadwiki-nuget/cadwiki.MVVM/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.0.0.1")]
-[assembly: AssemblyFileVersion("4.0.0.1")]
+[assembly: AssemblyVersion("25.0.0.2")]
+[assembly: AssemblyFileVersion("25.0.0.2")]


### PR DESCRIPTION
- Add central version in Directory.Build.props (25.0.0.2)
- Align 5 AssemblyInfo.cs files to unified version
- Create AssemblyInfo.cs for cadwiki.AC25.Interop
- Add cross-platform guard to cadwiki.DllReloader.csproj